### PR TITLE
(S/L) Problem: We need to properly escape UTF-8 in JSON.

### DIFF
--- a/src/fty_common_rest_utils_web.cc
+++ b/src/fty_common_rest_utils_web.cc
@@ -187,7 +187,7 @@ std::string escape (const char *string) {
     std::string::size_type i = 0;
     while (i < length) {
         char c = string[i];
-	int8_t width = UTF8::utf8_octets (string + i);
+        int8_t width = UTF8::utf8_octets (string + i);
         if (c == '"') {
             after.append ("\\\"");
         }
@@ -644,16 +644,15 @@ fty_common_rest_utils_web_test (bool verbose)
         {"\\\\\\",                                                      R"(\\\\\\)"},
         {"\\\\\\\\",                                                    R"(\\\\\\\\)"},
         {"\\\\\\\\\\",                                                  R"(\\\\\\\\\\)"},
-
-	// tests for version which does not escape UTF-8
-       //{"\uA66A",                                                    "\uA66A"},
-	//{"Ꙫ",                                                      "Ꙫ"},
-	//{"\uA66A Ꙫ",                                               "\uA66A Ꙫ"},
+        // tests for version which does not escape UTF-8
+        //{"\uA66A",                                                    "\uA66A"},
+        //{"Ꙫ",                                                         "Ꙫ"},
+        //{"\uA66A Ꙫ",                                                  "\uA66A Ꙫ"},
 
         {"\\uA66A",                                                     R"(\\uA66A)"},
-        {"Ꙫ",                                                        R"(\ua66a)"},
-        {"\\Ꙫ",                                                      R"(\\\ua66a)"},
-        {"\u040A Њ",                                                  R"(\u040a \u040a)"},
+        {"Ꙫ",                                                           R"(\ua66a)"},
+        {"\\Ꙫ",                                                         R"(\\\ua66a)"},
+        {"\u040A Њ",                                                    R"(\u040a \u040a)"},
         // do not escape control chars yet
         //{"\u0002\u0005\u0018\u001B",                                  R"(\u0002\u0005\u0018\u001b)"},
 
@@ -661,8 +660,8 @@ fty_common_rest_utils_web_test (bool verbose)
         {"\\\\uA66A",                                                   R"(\\\\uA66A)"},
         {"\\\\\uA66A",                                                  R"(\\\\\ua66a)"},
 
-        {"\\\\Ꙫ",                                                    R"(\\\\\ua66a)"},
-        {"\\\\\\Ꙫ",                                                  R"(\\\\\\\ua66a)"},
+        {"\\\\Ꙫ",                                                       R"(\\\\\ua66a)"},
+        {"\\\\\\Ꙫ",                                                     R"(\\\\\\\ua66a)"},
 
         {"first second \n third\n\n \\n \\\\\n fourth",                 R"(first second \\n third\\n\\n \\n \\\\\\n fourth)"},
         // do not escape control chars yet

--- a/src/fty_common_rest_utils_web.cc
+++ b/src/fty_common_rest_utils_web.cc
@@ -210,21 +210,21 @@ std::string escape (const char *string) {
             after.append ("\\\\");
         }
         // escape UTF-8 chars which have more than 1 byte
-	    else if (width > 1) {
-	        // allocate memory for "\u" + 4 hex digits + terminator
-	        // allocating 8 bytes just for performance doesn't make sense
-	        char *codepoint = (char *) calloc (7, sizeof (char));
-	        // calloc() takes care of zero termination, which utf8_to_codepoint() doesn't do
-	        UTF8::utf8_to_codepoint (string + i, &codepoint);
+        else if (width > 1) {
+            // allocate memory for "\u" + 4 hex digits + terminator
+            // allocating 8 bytes just for performance doesn't make sense
+            char *codepoint = (char *) calloc (7, sizeof (char));
+            // calloc() takes care of zero termination, which utf8_to_codepoint() doesn't do
+            UTF8::utf8_to_codepoint (string + i, &codepoint);
 
-	        std::string codepoint_str (codepoint);
-	        zstr_free (&codepoint);
-	        after.append (codepoint_str);
-	    }
+            std::string codepoint_str (codepoint);
+            zstr_free (&codepoint);
+            after.append (codepoint_str);
+        }
         else {
             after += c;
         }
-	i += width;
+        i += width;
     }
     return after;
 }

--- a/src/fty_common_rest_utils_web.cc
+++ b/src/fty_common_rest_utils_web.cc
@@ -37,6 +37,7 @@
 #include <cxxtools/split.h>
 #include <stdlib.h> // for random()
 #include <sys/syscall.h>
+#include <fty_common_utf8.h>
 
 //#include "shared/subprocess.h"
 #include "fty_common_rest_utils_web.h"
@@ -183,9 +184,10 @@ std::string escape (const char *string) {
         \u four-hex-digits
     ------------------------------
 */
-
-    for (std::string::size_type i = 0; i < length; ++i) {
+    std::string::size_type i = 0;
+    while (i < length) {
         char c = string[i];
+	int8_t width = UTF8::utf8_octets (string + i);
         if (c == '"') {
             after.append ("\\\"");
         }
@@ -207,9 +209,22 @@ std::string escape (const char *string) {
         else if (c == '\\') {
             after.append ("\\\\");
         }
+	// escape UTF-8 chars which have more than 1 byte
+	else if (width > 1) {
+	    // allocate memory for "\u" + 4 hex digits + terminator
+	    // allocating 8 bytes just for performance doesn't make sense
+	    char *codepoint = (char *) calloc (7, sizeof (char));
+	    // calloc() takes care of zero termination, which utf8_to_codepoint() doesn't do
+	    UTF8::utf8_to_codepoint (string + i, &codepoint);
+
+	    std::string codepoint_str (codepoint);
+	    zstr_free (&codepoint);
+	    after.append (codepoint_str);
+	}
         else {
             after += c;
         }
+	i += width;
     }
     return after;
 }
@@ -630,28 +645,28 @@ fty_common_rest_utils_web_test (bool verbose)
         {"\\\\\\\\",                                                    R"(\\\\\\\\)"},
         {"\\\\\\\\\\",                                                  R"(\\\\\\\\\\)"},
 
-        {"\uA66A",                                                      "\uA66A"},
-        {"Ꙫ",                                                           "Ꙫ"},
-        {"\uA66A Ꙫ",                                                    "\uA66A Ꙫ"},
+	// tests for version which does not escape UTF-8
+       //{"\uA66A",                                                    "\uA66A"},
+	//{"Ꙫ",                                                      "Ꙫ"},
+	//{"\uA66A Ꙫ",                                               "\uA66A Ꙫ"},
 
-        /*
         {"\\uA66A",                                                     R"(\\uA66A)"},
-        {"\\Ꙫ",                                                         R"(\\\u00ea\u0099\u00aa)"},
-        {"\u040A Њ",                                                    R"(\u00d0\u008a \u00d0\u008a)"},
-        {"\u0002\u0005\u0018\u001B",                                    R"(\u0002\u0005\u0018\u001b)"},
+        {"Ꙫ",                                                        R"(\ua66a)"},
+        {"\\Ꙫ",                                                      R"(\\\ua66a)"},
+        {"\u040A Њ",                                                  R"(\u040a \u040a)"},
+        // do not escape control chars yet
+        //{"\u0002\u0005\u0018\u001B",                                  R"(\u0002\u0005\u0018\u001b)"},
 
-        {"\\\uA66A",                                                    R"(\\\u00ea\u0099\u00aa)"},
+        {"\\\uA66A",                                                    R"(\\\ua66a)"},
         {"\\\\uA66A",                                                   R"(\\\\uA66A)"},
-        {"\\\\\uA66A",                                                  R"(\\\\\u00ea\u0099\u00aa)"},
+        {"\\\\\uA66A",                                                  R"(\\\\\ua66a)"},
 
-        {"\\\\Ꙫ",                                                       R"(\\\\\u00ea\u0099\u00aa)"},
-        {"\\\\\\Ꙫ",                                                     R"(\\\\\\\u00ea\u0099\u00aa)"},
-        */
+        {"\\\\Ꙫ",                                                    R"(\\\\\ua66a)"},
+        {"\\\\\\Ꙫ",                                                  R"(\\\\\\\ua66a)"},
 
         {"first second \n third\n\n \\n \\\\\n fourth",                 R"(first second \\n third\\n\\n \\n \\\\\\n fourth)"},
-        /*
-        {"first second \n third\n\"\n \\n \\\\\"\f\\\t\\u\u0007\\\n fourth", R"(first second \\n third\\n\"\\n \\n \\\\\"\\f\\\\t\\u\u0007\\\\n fourth)"}
-        */
+        // do not escape control chars yet
+        //{"first second \n third\n\"\n \\n \\\\\"\f\\\t\\u\u0007\\\n fourth", R"(first second \\n third\\n\"\\n \\n \\\\\"\\f\\\\t\\u\u0007\\\\n fourth)"}
     };
 
     // a valid json { key : utils::json::escape (<string> } is constructed,
@@ -668,7 +683,8 @@ fty_common_rest_utils_web_test (bool verbose)
         {"x\\\\\\\tx"},
         {"x\\Ꙫ\uA66A\n \\nx"},
         {"sdf\ndfg\n\\\n\\\\\n\b\tasd \b f\\bdfg"},
-        {"first second \n third\n\"\n \\n \\\\\"\f\\\t\\u\u0007\\\n fourth"}
+        // do not escape control chars yet
+        //{"first second \n third\n\"\n \\n \\\\\"\f\\\t\\u\u0007\\\n fourth"}
     };
 
 //    log_debug ("utils::json::escape","[utils::math::dtos][json][escape]");

--- a/src/fty_common_rest_utils_web.cc
+++ b/src/fty_common_rest_utils_web.cc
@@ -209,18 +209,18 @@ std::string escape (const char *string) {
         else if (c == '\\') {
             after.append ("\\\\");
         }
-	// escape UTF-8 chars which have more than 1 byte
-	else if (width > 1) {
-	    // allocate memory for "\u" + 4 hex digits + terminator
-	    // allocating 8 bytes just for performance doesn't make sense
-	    char *codepoint = (char *) calloc (7, sizeof (char));
-	    // calloc() takes care of zero termination, which utf8_to_codepoint() doesn't do
-	    UTF8::utf8_to_codepoint (string + i, &codepoint);
+        // escape UTF-8 chars which have more than 1 byte
+	    else if (width > 1) {
+	        // allocate memory for "\u" + 4 hex digits + terminator
+	        // allocating 8 bytes just for performance doesn't make sense
+	        char *codepoint = (char *) calloc (7, sizeof (char));
+	        // calloc() takes care of zero termination, which utf8_to_codepoint() doesn't do
+	        UTF8::utf8_to_codepoint (string + i, &codepoint);
 
-	    std::string codepoint_str (codepoint);
-	    zstr_free (&codepoint);
-	    after.append (codepoint_str);
-	}
+	        std::string codepoint_str (codepoint);
+	        zstr_free (&codepoint);
+	        after.append (codepoint_str);
+	    }
         else {
             after += c;
         }


### PR DESCRIPTION
Solution: Use fty_common_uf8 for that.

Signed-off-by: Jana Rapava <JanaRapava@eaton.com>
***********************************************************************
This depends on 42ity/fty-common#64 and will require Jenkins redeployment.