### PR TITLE
fty-common-rest/packaging : enforce DRAFTS=on packaging of this project

### DIFF
--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -1,7 +1,10 @@
 #!/usr/bin/make -f
 # -*- makefile -*-
 
-DRAFTS=no
+### MANUALLY MODIFIED: some classes are not marked stable, but are consumed,
+### so draft building is enforced
+###DRAFTS=no
+DRAFTS=yes
 DOCS=yes
 
 # OBS build: add

--- a/packaging/redhat/fty-common-rest.spec
+++ b/packaging/redhat/fty-common-rest.spec
@@ -26,7 +26,10 @@
 %if %{with drafts}
 %define DRAFTS yes
 %else
-%define DRAFTS no
+### MANUALLY MODIFIED: some classes are not marked stable, but are consumed,
+### so draft building is enforced
+###%define DRAFTS no
+%define DRAFTS yes
 %endif
 Name:           fty-common-rest
 Version:        1.0.0


### PR DESCRIPTION
A better solution would be to revise the code, and if there are no blockers to marking its API as stable, do so explicitly in `project.xml`.

Currently the most likely cause of recent test breakage is that a previous zproject regen PR disabled the hack to enforce draft builds, and so many routines were not seen by binary library consumers of the packaged component.