### PR TITLE
project.xml : mark as "legacy" classes/headers consumed by other…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,6 @@ env:
 # Prerequisite packages provided by OS distro and used "as is"
 pkg_deps_prereqs_distro: &pkg_deps_prereqs_distro
     - libsasl2-dev
-#   - libssl-dev
 
 # Prerequisite packages that may be built from source or used from
 # prebuilt packages of that source (usually not from an OS distro)

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -4,17 +4,13 @@
 ################################################################################
 nobase_include_HEADERS = \
     fty_common_rest.h \
-    fty_common_rest_utils_web.h \
-    fty_common_rest_library.h
-
-if ENABLE_DRAFTS
-nobase_include_HEADERS += \
     fty_common_rest_helpers.h \
     fty_common_rest_sasl.h \
     fty_common_rest_tokens.h \
-    fty_common_rest_audit_log.h
+    fty_common_rest_utils_web.h \
+    fty_common_rest_audit_log.h \
+    fty_common_rest_library.h
 
-endif
 
 
 ################################################################################

--- a/include/fty_common_rest_library.h
+++ b/include/fty_common_rest_library.h
@@ -79,29 +79,24 @@
 
 //  Opaque class structures to allow forward references
 //  These classes are stable or legacy and built in all releases
-typedef struct _fty_common_rest_utils_web_t fty_common_rest_utils_web_t;
-#define FTY_COMMON_REST_UTILS_WEB_T_DEFINED
-//  Draft classes are by default not built in stable releases
-#ifdef FTY_COMMON_REST_BUILD_DRAFT_API
 typedef struct _fty_common_rest_helpers_t fty_common_rest_helpers_t;
 #define FTY_COMMON_REST_HELPERS_T_DEFINED
 typedef struct _fty_common_rest_sasl_t fty_common_rest_sasl_t;
 #define FTY_COMMON_REST_SASL_T_DEFINED
 typedef struct _fty_common_rest_tokens_t fty_common_rest_tokens_t;
 #define FTY_COMMON_REST_TOKENS_T_DEFINED
+typedef struct _fty_common_rest_utils_web_t fty_common_rest_utils_web_t;
+#define FTY_COMMON_REST_UTILS_WEB_T_DEFINED
 typedef struct _fty_common_rest_audit_log_t fty_common_rest_audit_log_t;
 #define FTY_COMMON_REST_AUDIT_LOG_T_DEFINED
-#endif // FTY_COMMON_REST_BUILD_DRAFT_API
 
 
 //  Public classes, each with its own header file
-#include "fty_common_rest_utils_web.h"
-#ifdef FTY_COMMON_REST_BUILD_DRAFT_API
 #include "fty_common_rest_helpers.h"
 #include "fty_common_rest_sasl.h"
 #include "fty_common_rest_tokens.h"
+#include "fty_common_rest_utils_web.h"
 #include "fty_common_rest_audit_log.h"
-#endif // FTY_COMMON_REST_BUILD_DRAFT_API
 
 #ifdef FTY_COMMON_REST_BUILD_DRAFT_API
 

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -1,12 +1,7 @@
 #!/usr/bin/make -f
 # -*- makefile -*-
 
-#    NOTE: This file was customized after generation, be sure to keep it
-
-### MANUALLY MODIFIED: some classes are not marked stable, but are consumed,
-### so draft building is enforced
-###DRAFTS=no
-DRAFTS=yes
+DRAFTS=no
 DOCS=yes
 
 # OBS build: add

--- a/packaging/redhat/fty-common-rest.spec
+++ b/packaging/redhat/fty-common-rest.spec
@@ -1,6 +1,5 @@
 #
 #    fty-common-rest - Provides common RestAPI tools for agents
-#    NOTE: This file was customized after generation, be sure to keep it
 #
 #    Copyright (C) 2014 - 2018 Eaton
 #
@@ -27,10 +26,7 @@
 %if %{with drafts}
 %define DRAFTS yes
 %else
-### MANUALLY MODIFIED: some classes are not marked stable, but are consumed,
-### so draft building is enforced
-###%define DRAFTS no
-%define DRAFTS yes
+%define DRAFTS no
 %endif
 Name:           fty-common-rest
 Version:        1.0.0

--- a/project.xml
+++ b/project.xml
@@ -168,10 +168,14 @@
         </use>
     </use>
 
-    <class name = "fty_common_rest_helpers" selftest = "0" />
-    <class name = "fty_common_rest_sasl" selftest = "0" />
-    <class name = "fty_common_rest_tokens" selftest = "0" />
-    <class name = "fty_common_rest_utils_web" selftest = "1" stable = "1" />
-    <class name = "fty_common_rest_audit_log" selftest = "0">Manage audit log</class>
+    <!-- Note: Stability of classes below is marked as "legacy" somewhat
+         incorrectly: these interfaces may yet evolve (to be addressed by
+         the team across whole product ecosystem, so potentially not yet
+         "stable") and must be built and delivered (so not "draft"). -->
+    <class name = "fty_common_rest_helpers" selftest = "0" state = "legacy" />
+    <class name = "fty_common_rest_sasl" selftest = "0" state = "legacy" />
+    <class name = "fty_common_rest_tokens" selftest = "0" state = "legacy" />
+    <class name = "fty_common_rest_utils_web" selftest = "1" state = "legacy" />
+    <class name = "fty_common_rest_audit_log" selftest = "0" state = "legacy">Manage audit log</class>
 
 </project>

--- a/src/Makemodule.am
+++ b/src/Makemodule.am
@@ -13,17 +13,12 @@ lib_LTLIBRARIES += src/libfty_common_rest.la
 pkgconfig_DATA = src/libfty_common_rest.pc
 
 src_libfty_common_rest_la_SOURCES = \
-    src/fty_common_rest_utils_web.cc \
-    src/platform.h
-
-if ENABLE_DRAFTS
-src_libfty_common_rest_la_SOURCES += \
     src/fty_common_rest_helpers.cc \
     src/fty_common_rest_sasl.cc \
     src/fty_common_rest_tokens.cc \
-    src/fty_common_rest_audit_log.cc
-
-endif
+    src/fty_common_rest_utils_web.cc \
+    src/fty_common_rest_audit_log.cc \
+    src/platform.h
 
 if ENABLE_DRAFTS
 src_libfty_common_rest_la_SOURCES += \


### PR DESCRIPTION
…components but which may change

The stability state machine allows for 3 states in zproject:
````
The allowed states are:

* draft - the class or method is not built/installed in stable releases.
* stable - the class or method is always built and installed.
  A method may not be changed once marked as stable.
* legacy - the class or method is always built and installed.
  It may carry a warning that support can be withdrawn at any time.
````

This change also removes now unneeded customization in packaging recipes.