### PR TITLE
Problem: fty-metric-cache stop to belong to our systemd unit service

### DIFF
--- a/src/fty_common_rest_helpers.cc
+++ b/src/fty_common_rest_helpers.cc
@@ -103,7 +103,6 @@ std::map <std::string, std::string> systemctl_service_names = {
     { "fty-sensor-gpio", "" },
     { "fty-nut-configurator", "" },
     { "fty-metric-compute", "" },
-    { "fty-metric-cache", "" },
     { "fty-alert-flexible", "" },
     // legacy compatibility
     { "bios-agent-smtp", "fty-email" },


### PR DESCRIPTION
Signed-off-by: Gerald Guillaume <geraldguillaume@eaton.com>