### PR TITLE
fty_common_rest_helpers.cc for systemctl.ecpp …

### DIFF
--- a/src/fty_common_rest_helpers.cc
+++ b/src/fty_common_rest_helpers.cc
@@ -79,6 +79,7 @@ std::map <std::string, std::string> systemctl_service_names = {
     { "fty-metric-tpower", "" },
     { "bios-agent-inventory", "" },
     { "fty-discovery", "" },
+    { "fty-hostname-setup", "" },
     { "fty-info", "" },
     { "fty-mdns-sd", "" },
     { "fty-metric-snmp", "" },


### PR DESCRIPTION
…allow to manage fty-hostname-setup service

Part of fix to CI fallout due to https://github.com/42ity/fty-core/pull/382

See also https://github.com/42ity/fty-core/pull/387