### PR TITLE
Fix the build for variadic macro warnings

### DIFF
--- a/include/fty_common_rest_utils_web.h
+++ b/include/fty_common_rest_utils_web.h
@@ -192,7 +192,7 @@ _die_asprintf(
         constexpr size_t __http_die__key_idx__ = _die_idx<_WSErrorsCOUNT-1>((const char*)key); \
         static_assert(__http_die__key_idx__ != 0, "Can't find '" key "' in list of error messages. Either add new one either fix the typo in key"); \
         char *__http_die__error_message__ = NULL; \
-        _die_asprintf(&__http_die__error_message__, _errors.at(__http_die__key_idx__).message, ##__VA_ARGS__, "", "", "", "", "" ); \
+        _die_asprintf(&__http_die__error_message__, _errors.at(__http_die__key_idx__).message, ##__VA_ARGS__); \
         if (::getenv ("BIOS_LOG_LEVEL") && !strcmp (::getenv ("BIOS_LOG_LEVEL"), "LOG_DEBUG")) { \
             std::string __http_die__debug__ = {__FILE__}; \
             __http_die__debug__ += ": " + std::to_string (__LINE__); \
@@ -250,7 +250,7 @@ do { \
     static_assert(__http_die__key_idx__ != 0, "Can't find '" key "' in list of error messages. Either add new one either fix the typo in key"); \
     (errors).http_code = _errors.at (__http_die__key_idx__).http_code; \
     char *__http_die__error_message__ = NULL; \
-    _die_asprintf(&__http_die__error_message__, _errors.at(__http_die__key_idx__).message, ##__VA_ARGS__, "", "", "", "", "" ); \
+    _die_asprintf(&__http_die__error_message__, _errors.at(__http_die__key_idx__).message, ##__VA_ARGS__); \
     (errors).errors.push_back (std::make_tuple (_errors.at (__http_die__key_idx__).err_code, __http_die__error_message__, (debug))); \
     free (__http_die__error_message__); \
 } \
@@ -334,7 +334,7 @@ do { \
     constexpr size_t __http_die__key_idx__ = _die_idx<_WSErrorsCOUNT-1>((const char*)key); \
     static_assert(__http_die__key_idx__ != 0, "Can't find '" key "' in list of error messages. Either add new one either fix the typo in key"); \
     char *__http_die__error_message__ = NULL; \
-    _die_asprintf(&__http_die__error_message__, _errors.at(__http_die__key_idx__).message, ##__VA_ARGS__, "", "", "", "", "" ); \
+    _die_asprintf(&__http_die__error_message__, _errors.at(__http_die__key_idx__).message, ##__VA_ARGS__); \
     str = __http_die__error_message__; \
     idx = __http_die__key_idx__; \
     free (__http_die__error_message__); \
@@ -357,7 +357,7 @@ while (0)
         constexpr size_t __http_die__key_idx__ = _die_idx<_WSErrorsCOUNT-1>((const char*)key); \
         static_assert(__http_die__key_idx__ != 0, "Can't find '" key "' in list of error messages. Either add new one either fix the typo in key"); \
         char *__http_die__error_message__ = NULL; \
-        _die_asprintf(&__http_die__error_message__, _errors.at(__http_die__key_idx__).message, ##__VA_ARGS__, "", "", "", "", "" ); \
+        _die_asprintf(&__http_die__error_message__, _errors.at(__http_die__key_idx__).message, ##__VA_ARGS__); \
         std::string str{__http_die__error_message__}; \
         free(__http_die__error_message__); \
         log_warning("throw BiosError{%zu, \"%s\"}", __http_die__key_idx__, str.c_str());\

--- a/include/fty_common_rest_utils_web.h
+++ b/include/fty_common_rest_utils_web.h
@@ -200,12 +200,12 @@ _die_asprintf(
 // This wrapper allows to code `http_add_error (debug, errors, "not-authorized", "");`
 // which pads an empty variadic argument because C++11 requires to have one in macros
 // and yet avoid formatting errors because the format string does not refer to it:
-#define _safe_die_asprintf(buf, argc, msgfmt, argv...) \
+#define _safe_die_asprintf(buf, argc, msgfmt, ...) \
     do { \
         if (argc == 0) { \
             _die_asprintf(buf, msgfmt); \
         } else { \
-            _die_asprintf(buf, msgfmt, ##argv); \
+            _die_asprintf(buf, msgfmt, ##__VA_ARGS__); \
         } \
     } \
     while(0)

--- a/include/fty_common_rest_utils_web.h
+++ b/include/fty_common_rest_utils_web.h
@@ -193,10 +193,8 @@ _die_asprintf(
 /* Note: Code below relies on GCC extension that a ", ##__VA_ARGS" with double
  * hash chars, expands to the args if present, or removes the comma if not.
  */
-// From https://stackoverflow.com/a/2124433/4715872 :
-#define       NUMARGS(...)  (sizeof((int[]){0, ##__VA_ARGS__})/sizeof(int)-1)
 
-// FIXME: Use non-zero values of argc to pad to needed amount with empty strings if NUMARGS<argc
+// FIXME: Use non-zero values of argc to pad to needed amount with empty strings if argn<argc
 // This wrapper allows to code `http_add_error (debug, errors, "not-authorized", "");`
 // which pads an empty variadic argument because C++11 requires to have one in macros
 // and yet avoid formatting errors because the format string does not refer to it.
@@ -205,8 +203,9 @@ _die_asprintf(
 #define _safe_die_asprintf(buf, argc, ...) \
     do { \
         const char* args[] = { __VA_ARGS__ }; \
-        static_assert(sizeof(args) > 0, "No format and further strings passed into _safe_die_asprintf()"); \
-        static_assert((sizeof(args)/sizeof(char*)) > argc, "Too few vararg strings for the error message passed into _safe_die_asprintf()"); \
+        const size_t argn = (sizeof(args)/sizeof(const char*)); \
+        static_assert( (argn > 0), "No format and further strings passed into _safe_die_asprintf()"); \
+        static_assert( (argn > argc), "Too few vararg strings for the error message passed into _safe_die_asprintf()"); \
         switch (argc) { \
             case 0: _die_asprintf(buf, "%s", args[0]); break; \
             case 1: _die_asprintf(buf, args[0], args[1]); break; \

--- a/include/fty_common_rest_utils_web.h
+++ b/include/fty_common_rest_utils_web.h
@@ -205,6 +205,7 @@ _die_asprintf(
         const char* args[] = { __VA_ARGS__ }; \
         const size_t argn = (sizeof(args)/sizeof(const char*)); \
         static_assert( (argn > 0), "No format and further strings passed into _safe_die_asprintf()"); \
+        static_assert( (argc >= 0), "Negative count of expected vararg strings for the error message passed into _safe_die_asprintf()"); \
         static_assert( (argn > argc), "Too few vararg strings for the error message passed into _safe_die_asprintf()"); \
         switch (argc) { \
             case 0: _die_asprintf(buf, "%s", args[0]); break; \

--- a/include/fty_common_rest_utils_web.h
+++ b/include/fty_common_rest_utils_web.h
@@ -70,8 +70,11 @@ typedef std::array<_WSError, _WSErrorsCOUNT> _WSErrors;
 
 // WARNING!!! - don't use anything else than %s as format parameter for .message
 //
-// FIXME: gcc-8 complains about this trick so it is due to be removed
-// in favor of message_expansions
+// FIXME: LEGACY NOTE: Updated _safe_die_asprintf__legacy() defined below
+// supports the behavior from next paragraph, to support old code that might
+// rely on it, in a way that works with modern compilers. I do not know if
+// there are nowadays any use-cases that actually rely on this ambiguity.
+//
 // TL;DR;
 // The .messages are supposed to be called with FEWER formatting arguments than defined.
 // To avoid issues with going to unallocated memory, the _die_asprintf is called with
@@ -198,7 +201,9 @@ _die_asprintf(
 // which pads an empty variadic argument because C++11 requires to have one in macros
 // and yet avoid formatting errors because the format string does not refer to it.
 // Note that in practice it must have 3+ arguments (char** buf, int argc, msgfmt, ...)
-// but to work around gcc warnings it hides msgfmt as the first variadic argument:
+// but to work around gcc warnings it hides msgfmt as the first variadic argument.
+// Note that expandable arguments here must be "char*" strings; hopefully args[]
+// definition below will complain at compile-time about incompatible arguments.
 // LEGACY: Uses non-zero values of argc to pad to needed amount with empty strings
 // if argn<argc because older code could rely on this:
 //    _safe_die_asprintf(buf, 0, "not-authorized") => argc==0, argn==1

--- a/include/fty_common_rest_utils_web.h
+++ b/include/fty_common_rest_utils_web.h
@@ -97,20 +97,20 @@ static constexpr const _WSErrors _errors = { {
     {"bad-input",                HTTP_BAD_REQUEST,              57,      TRANSLATE_ME_IGNORE_PARAMS ("Incorrect input. %s"), 1 },
     {"licensing-err",            HTTP_FORBIDDEN,                58,      TRANSLATE_ME_IGNORE_PARAMS ("Action forbidden in current licensing state. %s"), 1 },
     {"upstream-err",             HTTP_BAD_GATEWAY,              59,      TRANSLATE_ME_IGNORE_PARAMS ("Server which was contacted to fulfill the request has returned an error. %s"), 1 }
-//    {.key = "undefined",                .http_code = HTTP_TEAPOT,                   .err_code = INT_MIN, .message = "I'm a teapot!" },
-//    {.key = "internal-error",           .http_code = HTTP_INTERNAL_SERVER_ERROR,    .err_code = 42,      .message = "Internal Server Error. %s" },
-//    {.key = "not-authorized",           .http_code = HTTP_UNAUTHORIZED,             .err_code = 43,      .message = "You are not authenticated or your rights are insufficient."},
-//    {.key = "element-not-found",        .http_code = HTTP_NOT_FOUND,                .err_code = 44,      .message = "Element '%s' not found."},
-//    {.key = "method-not-allowed",       .http_code = HTTP_METHOD_NOT_ALLOWED,       .err_code = 45,      .message = "Http method '%s' not allowed."},
-//    {.key = "request-param-required",   .http_code = HTTP_BAD_REQUEST,              .err_code = 46,      .message = "Parameter '%s' is required." },
-//    {.key = "request-param-bad",        .http_code = HTTP_BAD_REQUEST,              .err_code = 47,      .message = "Parameter '%s' has bad value. Received %s. Expected %s" },
-//    {.key = "bad-request-document",     .http_code = HTTP_BAD_REQUEST,              .err_code = 48,      .message = "Request document has invalid syntax. %s" },
-//    {.key = "data-conflict",            .http_code = HTTP_CONFLICT,                 .err_code = 50,      .message = "Element '%s' cannot be processed because of conflict. %s"},
-//    {.key = "action-forbidden",         .http_code = HTTP_FORBIDDEN,                .err_code = 51,      .message = "%s is forbidden. %s"},
-//    {.key = "parameter-conflict",       .http_code = HTTP_BAD_REQUEST,              .err_code = 52,      .message = "Request cannot be processed because of conflict in parameters. %s"},
-//    {.key = "content-too-big",          .http_code = HTTP_REQUEST_ENTITY_TOO_LARGE, .err_code = 53,      .message = "Content size is too big, maximum size is %s" },
-//    {.key = "not-found",                .http_code = HTTP_NOT_FOUND,                .err_code = 54,      .message = "%s does not exist." },
-//    {.key = "precondition-failed",      .http_code = HTTP_PRECONDITION_FAILED,      .err_code = 55,      .message = "Precondition failed - %s" }
+//    {.key = "undefined",                .http_code = HTTP_TEAPOT,                   .err_code = INT_MIN, .message = "I'm a teapot!", .message_expansions = 0 },
+//    {.key = "internal-error",           .http_code = HTTP_INTERNAL_SERVER_ERROR,    .err_code = 42,      .message = "Internal Server Error. %s", .message_expansions = 1 },
+//    {.key = "not-authorized",           .http_code = HTTP_UNAUTHORIZED,             .err_code = 43,      .message = "You are not authenticated or your rights are insufficient.", .message_expansions = 0 },
+//    {.key = "element-not-found",        .http_code = HTTP_NOT_FOUND,                .err_code = 44,      .message = "Element '%s' not found.", .message_expansions = 1 },
+//    {.key = "method-not-allowed",       .http_code = HTTP_METHOD_NOT_ALLOWED,       .err_code = 45,      .message = "Http method '%s' not allowed.", .message_expansions = 1 },
+//    {.key = "request-param-required",   .http_code = HTTP_BAD_REQUEST,              .err_code = 46,      .message = "Parameter '%s' is required.", .message_expansions = 1 },
+//    {.key = "request-param-bad",        .http_code = HTTP_BAD_REQUEST,              .err_code = 47,      .message = "Parameter '%s' has bad value. Received %s. Expected %s", .message_expansions = 3 },
+//    {.key = "bad-request-document",     .http_code = HTTP_BAD_REQUEST,              .err_code = 48,      .message = "Request document has invalid syntax. %s", .message_expansions = 1 },
+//    {.key = "data-conflict",            .http_code = HTTP_CONFLICT,                 .err_code = 50,      .message = "Element '%s' cannot be processed because of conflict. %s", .message_expansions = 2 },
+//    {.key = "action-forbidden",         .http_code = HTTP_FORBIDDEN,                .err_code = 51,      .message = "%s is forbidden. %s", .message_expansions = 2 },
+//    {.key = "parameter-conflict",       .http_code = HTTP_BAD_REQUEST,              .err_code = 52,      .message = "Request cannot be processed because of conflict in parameters. %s", .message_expansions = 1 },
+//    {.key = "content-too-big",          .http_code = HTTP_REQUEST_ENTITY_TOO_LARGE, .err_code = 53,      .message = "Content size is too big, maximum size is %s", .message_expansions = 1 },
+//    {.key = "not-found",                .http_code = HTTP_NOT_FOUND,                .err_code = 54,      .message = "%s does not exist.", .message_expansions = 1 },
+//    {.key = "precondition-failed",      .http_code = HTTP_PRECONDITION_FAILED,      .err_code = 55,      .message = "Precondition failed - %s", .message_expansions = 1 }
     } };
 #undef HTTP_TEAPOT
 

--- a/src/fty_common_rest_helpers.cc
+++ b/src/fty_common_rest_helpers.cc
@@ -351,7 +351,7 @@ check_user_permissions (
     if (permissions.count (user.profile ()) != 1) {
         // actually it is not an error :)
         log_info ("Permission not defined for given profile");
-        http_add_error (debug, errors, "not-authorized", "");
+        http_add_error (debug, errors, "not-authorized");
         return;
     }
 
@@ -367,7 +367,7 @@ check_user_permissions (
         return;
     }
 
-    http_add_error (debug, errors, "not-authorized", "");
+    http_add_error (debug, errors, "not-authorized");
     return;
 }
 

--- a/src/fty_common_rest_helpers.cc
+++ b/src/fty_common_rest_helpers.cc
@@ -351,7 +351,7 @@ check_user_permissions (
     if (permissions.count (user.profile ()) != 1) {
         // actually it is not an error :)
         log_info ("Permission not defined for given profile");
-        http_add_error (debug, errors, "not-authorized");
+        http_add_error (debug, errors, "not-authorized", "");
         return;
     }
 
@@ -367,7 +367,7 @@ check_user_permissions (
         return;
     }
 
-    http_add_error (debug, errors, "not-authorized");
+    http_add_error (debug, errors, "not-authorized", "");
     return;
 }
 


### PR DESCRIPTION
Jumping between two extremes:

* Requiring at least one argument in variadic macro:
````
make[1]: Entering directory '/dev/shm/jenkins-swarm-client/workspace/y-common-rest_featureimage_deb10/tmp/build-withDRAFT'

  CXX      src/libfty_common_rest_la-fty_common_rest_helpers.lo

src/fty_common_rest_helpers.cc:354:56: error: ISO C++11 requires at least one argument for the "..." in a variadic macro [-Werror]
         http_add_error (debug, errors, "not-authorized");
                                                        ^

src/fty_common_rest_helpers.cc:370:52: error: ISO C++11 requires at least one argument for the "..." in a variadic macro [-Werror]
     http_add_error (debug, errors, "not-authorized");
                                                    ^
cc1plus: all warnings being treated as errors
````

* vs. forbidding extra arguments that do not match a format string:
````
In file included from src/fty_common_rest_helpers.cc:32:
src/fty_common_rest_helpers.cc: In function 'void check_user_permissions(const UserInfo&, const tnt::HttpRequest&, const std::map<BiosProfile, std::__cxx11::basic_string<char> >&, std::__cxx11::string, http_errors_t&)':
./include/fty_common_rest_utils_web.h:253:105: error: too many arguments for format [-Werror=format-extra-args]
     _die_asprintf(&__http_die__error_message__, _errors.at(__http_die__key_idx__).message, ##__VA_ARGS__); \
                                                                                                         ^
src/fty_common_rest_helpers.cc:354:9: note: in expansion of macro 'http_add_error'
         http_add_error (debug, errors, "not-authorized", "");
         ^~~~~~~~~~~~~~
./include/fty_common_rest_utils_web.h:253:105: error: too many arguments for format [-Werror=format-extra-args]
     _die_asprintf(&__http_die__error_message__, _errors.at(__http_die__key_idx__).message, ##__VA_ARGS__); \
                                                                                                         ^
src/fty_common_rest_helpers.cc:370:5: note: in expansion of macro 'http_add_error'
     http_add_error (debug, errors, "not-authorized", "");
     ^~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
````
