### PR TITLE
Fixed non std constexpr function for clang

### DIFF
--- a/include/fty_common_rest_utils_web.h
+++ b/include/fty_common_rest_utils_web.h
@@ -113,7 +113,7 @@ static constexpr const _WSErrors _errors = { {
 
 constexpr bool _strcmp(char const * a, char const * b)
 {
-    return *a == *b && (*a == '\0' || _strcmp(a + 1, b + 1));
+    return (*a && *b) ? (*a == *b && _strcmp(a + 1, b + 1)) : (!*a && !*b);
 }
 
 template <size_t N>

--- a/include/fty_common_rest_utils_web.h
+++ b/include/fty_common_rest_utils_web.h
@@ -111,12 +111,17 @@ static constexpr const _WSErrors _errors = { {
     } };
 #undef HTTP_TEAPOT
 
+constexpr bool _strcmp(char const * a, char const * b)
+{
+    return *a == *b && (*a == '\0' || _strcmp(a + 1, b + 1));
+}
+
 template <size_t N>
 constexpr ssize_t
 _die_idx(const char* key)
 {
     static_assert(std::tuple_size<_WSErrors>::value > N, "_die_idx asked for too big N");
-    return (strcmp(_errors.at(N).key, key) == 0 || strcmp(_errors.at(N).message, key) == 0) ? N: _die_idx<N-1>(key);
+    return (_strcmp(_errors.at(N).key, key) || _strcmp(_errors.at(N).message, key)) ? N: _die_idx<N-1>(key);
 }
 
 template <>
@@ -124,7 +129,7 @@ constexpr ssize_t
 _die_idx<1>(const char* key)
 {
     static_assert(std::tuple_size<_WSErrors>::value > 1 , "_die_idx asked for too big N");
-    return (strcmp(_errors.at(1).key, key) == 0 || strcmp(_errors.at(1).message, key) == 0) ? 1: 0;
+    return (_strcmp(_errors.at(1).key, key) || _strcmp(_errors.at(1).message, key)) ? 1: 0;
 }
 
 static int


### PR DESCRIPTION
GCC uses builtin function strcmp which is constexp, and IMHO this behavior is a bug because stdlib version is not constexpr. As a result - Clang compilation fails.
So, I've added _strcmp constexpr function, because I don't want to change all this usage.

This PR connot be build for this moment due variadic macros, which should be solved in previous PR
