### PR TITLE
Unit test errors macros

### DIFF
--- a/include/fty_common_rest_utils_web.h
+++ b/include/fty_common_rest_utils_web.h
@@ -75,6 +75,7 @@ typedef std::array<_WSError, _WSErrorsCOUNT> _WSErrors;
 // **5** additional empty strings, which fill sefgaults for other formatting specifiers.
 
 #define HTTP_TEAPOT 418 //see RFC2324
+// Note: array index of "undefined" is 0 and will be rejected by macros below
 static constexpr const _WSErrors _errors = { {
     {"undefined",                HTTP_TEAPOT,                   INT_MIN, TRANSLATE_ME_IGNORE_PARAMS ("I'm a teapot!") },
     {"internal-error",           HTTP_INTERNAL_SERVER_ERROR,    42,      TRANSLATE_ME_IGNORE_PARAMS ("Internal Server Error. %s") },

--- a/src/fty_common_rest_utils_web.cc
+++ b/src/fty_common_rest_utils_web.cc
@@ -918,6 +918,34 @@ fty_common_rest_utils_web_test (bool verbose)
         roots.clear();
     }
 
+    {
+        log_debug ("fty-common-rest-utils-web: Test #13");
+        log_debug ("macro::bios_error_idx");
+        std::string err, expectation;
+        int idx;
+
+        bios_error_idx(idx, err, "internal-error", "test13");
+        expectation = "{ \"key\": \"Internal Server Error. {{var1}}\", \"variables\": { \"var1\": \"test13\" } }";
+        log_debug("Got err_str: %s", err.c_str());
+        log_debug("Expectation: %s", expectation.c_str());
+        assert (!streq(err.c_str(), "Internal Server Error. test13"));
+        assert (streq(err.c_str(), expectation.c_str()));
+
+        // This one fails because array index of "undefined" is 0
+        /*
+        {
+            bool passed = false;
+            try {
+                bios_error_idx(idx, err, "undefined");
+                assert (streq(err.c_str(), "I'm a teapot!"));
+                passed = true;
+            } catch(std::exception e) {
+                assert (passed == false);
+            }
+        }
+        */
+    }
+
     printf ("OK\n");
 }
 

--- a/src/fty_common_rest_utils_web.cc
+++ b/src/fty_common_rest_utils_web.cc
@@ -926,7 +926,7 @@ fty_common_rest_utils_web_test (bool verbose)
 
         bios_error_idx(idx, err, "internal-error", "test13");
         expectation = "{ \"key\": \"Internal Server Error. {{var1}}\", \"variables\": { \"var1\": \"test13\" } }";
-        log_debug("Got err_str: %s", err.c_str());
+        log_debug("Got err_str: %s\n\tat index %i", err.c_str(), idx);
         log_debug("Expectation: %s", expectation.c_str());
         assert (!streq(err.c_str(), "Internal Server Error. test13"));
         assert (streq(err.c_str(), expectation.c_str()));

--- a/src/fty_common_rest_utils_web.cc
+++ b/src/fty_common_rest_utils_web.cc
@@ -929,6 +929,9 @@ fty_common_rest_utils_web_test (bool verbose)
             "\"variables\": { \"var1\": \"test13\" } }";
         log_debug("Got err_str: %s\n\tat index %i", err.c_str(), idx);
         log_debug("Expectation: %s", expectation.c_str());
+        // Verify that we did get the translated string,
+        // not the expansion of original printf pattern in
+        // the errors array from fty_common_rest_utils_web.h :
         assert (!streq(err.c_str(), "Internal Server Error. test13"));
         assert (streq(err.c_str(), expectation.c_str()));
 

--- a/src/fty_common_rest_utils_web.cc
+++ b/src/fty_common_rest_utils_web.cc
@@ -925,7 +925,8 @@ fty_common_rest_utils_web_test (bool verbose)
         int idx;
 
         bios_error_idx(idx, err, "internal-error", "test13");
-        expectation = "{ \"key\": \"Internal Server Error. {{var1}}\", \"variables\": { \"var1\": \"test13\" } }";
+        expectation = "{ \"key\": \"Internal Server Error. {{var1}}\", "
+            "\"variables\": { \"var1\": \"test13\" } }";
         log_debug("Got err_str: %s\n\tat index %i", err.c_str(), idx);
         log_debug("Expectation: %s", expectation.c_str());
         assert (!streq(err.c_str(), "Internal Server Error. test13"));

--- a/src/fty_common_rest_utils_web.cc
+++ b/src/fty_common_rest_utils_web.cc
@@ -916,9 +916,9 @@ fty_common_rest_utils_web_test (bool verbose)
         // Cleanup
         utils::config::roots_destroy(roots);
         roots.clear();
-
-        printf ("OK\n");
     }
+
+    printf ("OK\n");
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
For a bit of late night fun on own time, wanted to check how different generations of the code around our macros behave. Committing the simple mechanism for that here.

In the spirit of making sure the refactoring is valid, verified that the same unit-test code succeeds (produces expected string) in both the codebase before last week's changes to fix macros, with my changes reverted since, and against current master.