### PR TITLE
fty_common_rest_sasl.cc: hotfix coverity error detected

### DIFF
--- a/src/fty_common_rest_sasl.cc
+++ b/src/fty_common_rest_sasl.cc
@@ -255,7 +255,7 @@ bool authenticate(const char* userid, const char* passwd, const char* service)
             return false;
         }
 
-        count = int(sizeof(response)) < count ? sizeof(response) : count;
+        count = (int(sizeof(response) - 1) < count) ? (sizeof(response) - 1) : count;
         if (retry_read(s, response, count) < count) {
             close(s);
             fprintf(stderr, "read failed\n");


### PR DESCRIPTION
  "issues": [
14:45:43      {
14:45:43        "fileName": "/var/lib/jenkins-worker/workspace/ty-common-rest_release_IPM-2.5.0/src/fty_common_rest_sasl.cc",
14:45:43        "type": "Out-of-bounds write (OVERRUN)",
14:45:43        "category": "TOP_41 Memory - corruptions",
14:45:43        "severity": "ERROR",
14:45:43        "lineStart": "164",
14:45:43        "lineEnd": "264",
14:45:43        "message": "Out-of-bounds write to a buffer",